### PR TITLE
Add ESLint dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      eslint:
+        patterns:
+          - "*eslint*"


### PR DESCRIPTION
This patch makes Dependabot update ESLint related packages at the same time to avoid conflicts.