### PR TITLE
Drop unused js-yaml dependency, bump @types/node and codeql-action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.37.3
+      uses: github/codeql-action/init@v4.37.6
       with:
         languages: ${{ matrix.language }}
         source-root: src
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.37.3
+      uses: github/codeql-action/autobuild@v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.37.3
+      uses: github/codeql-action/analyze@v4.37.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "@biomejs/biome": "^2.5.7",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-node-resolve": "^16.0.3",
-        "@types/node": "^26.1.2",
-        "js-yaml": "^4.1.1",
+        "@types/node": "^26.2.0",
         "rollup": "^4.62.4",
         "typescript": "^5.9.3"
       },
@@ -720,9 +719,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -735,13 +734,6 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -836,19 +828,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
-      }
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "@biomejs/biome": "^2.5.7",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
-    "@types/node": "^26.1.2",
-    "js-yaml": "^4.1.1",
+    "@types/node": "^26.2.0",
     "rollup": "^4.62.4",
     "typescript": "^5.9.3"
   }


### PR DESCRIPTION
js-yaml was declared as a devDependency but never imported anywhere in this repo - leftover from the original template. Removing it also clears the high-severity quadratic-complexity-DoS advisory that was flagged against it (4.0.0-4.3.0). Bumps @types/node to the latest patch and github/codeql-action's three steps to v4.37.6.

Also verified @rollup/plugin-commonjs in rollup.config.js is load- bearing: removing it breaks bundling because @actions/core's transitive dependency `tunnel` is CommonJS, so it stays.